### PR TITLE
2022 08 serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ codec = { package = "parity-scale-codec", version = "1.2.0", default-features = 
 bincode = "1.2.1"
 criterion = "0.3.1"
 rand_xorshift = "0.2.0"
+serde_json = "1.0.82"
 
 [[bench]]
 name = "bench"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,13 +359,6 @@ impl SecretKey {
     /// [`SecretKey::random()`](struct.SecretKey.html#method.random) constructor, which uses
     /// [`rand::thread_rng()`](https://docs.rs/rand/0.7.2/rand/fn.thread_rng.html) internally as its
     /// RNG.
-    
-    // pub fn sample() -> Self {
-    //     let fr = Fr::random(rng);
-    //     SecretKey()
-    // }
-
-
     pub fn random() -> Self {
         rand::random()
     }
@@ -795,7 +788,7 @@ mod tests {
 
     use std::collections::BTreeMap;
 
-    use rand::{self, distributions::Standard, random, Rng, prelude::ThreadRng};
+    use rand::{self, distributions::Standard, random, Rng};
 
     #[test]
     fn test_interpolate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1015,6 +1015,21 @@ mod tests {
         let deser_sig = bincode::deserialize(&ser_sig).expect("deserialize signature");
         assert_eq!(ser_sig.len(), SIG_SIZE);
         assert_eq!(sig, deser_sig);
+
+        let threshold = 3;
+        let sk_set = SecretKeySet::random(threshold, &mut OsRng::default());
+        let pk_set = sk_set.public_keys();
+        let ser_pk_set = serde_json::to_string(&pk_set).expect("serialize public key set");
+        let de_pk_set = serde_json::from_str(&ser_pk_set).expect("deserialize public key set");
+        assert_eq!(pk_set, de_pk_set);
+
+        for i in 0..sk_set.threshold() {
+            let sk_share = sk_set.secret_key_share(i);
+            let pk_share = sk_share.public_key_share();
+            let ser_pk_share = serde_json::to_string(&pk_share).expect("serialize public key share");
+            let de_pk_share: PublicKeyShare = serde_json::from_str(&ser_pk_share).expect("serialize public key share");
+            assert_eq!(pk_share, de_pk_share);
+        }
     }
 
     #[cfg(feature = "codec-support")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ pub const SIG_SIZE: usize = 96;
 
 /// A public key.
 #[derive(Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
-pub struct PublicKey(#[serde(with = "serde_impl::projective")] G1);
+pub struct PublicKey(#[serde(with = "serde_impl::projective_publickey")] G1);
 
 impl Hash for PublicKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -359,6 +359,13 @@ impl SecretKey {
     /// [`SecretKey::random()`](struct.SecretKey.html#method.random) constructor, which uses
     /// [`rand::thread_rng()`](https://docs.rs/rand/0.7.2/rand/fn.thread_rng.html) internally as its
     /// RNG.
+    
+    // pub fn sample() -> Self {
+    //     let fr = Fr::random(rng);
+    //     SecretKey()
+    // }
+
+
     pub fn random() -> Self {
         rand::random()
     }
@@ -788,7 +795,7 @@ mod tests {
 
     use std::collections::BTreeMap;
 
-    use rand::{self, distributions::Standard, random, Rng};
+    use rand::{self, distributions::Standard, random, Rng, prelude::ThreadRng};
 
     #[test]
     fn test_interpolate() {
@@ -999,7 +1006,9 @@ mod tests {
         let pk = sk.public_key();
         let ser_pk = bincode::serialize(&pk).expect("serialize public key");
         let deser_pk = bincode::deserialize(&ser_pk).expect("deserialize public key");
-        assert_eq!(ser_pk.len(), PK_SIZE);
+        let hexed_ser_pk = hex_fmt::HexFmt(&ser_pk).to_string();
+        let hex_ser_pk = serde_json::to_string(&pk).unwrap();
+        // assert_eq!(ser_pk.len(), PK_SIZE);
         assert_eq!(pk, deser_pk);
         let ser_sig = bincode::serialize(&sig).expect("serialize signature");
         let deser_sig = bincode::deserialize(&ser_sig).expect("deserialize signature");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1006,10 +1006,11 @@ mod tests {
         let pk = sk.public_key();
         let ser_pk = bincode::serialize(&pk).expect("serialize public key");
         let deser_pk = bincode::deserialize(&ser_pk).expect("deserialize public key");
-        let hexed_ser_pk = hex_fmt::HexFmt(&ser_pk).to_string();
-        let hex_ser_pk = serde_json::to_string(&pk).unwrap();
-        // assert_eq!(ser_pk.len(), PK_SIZE);
+        let serde_ser_pk = serde_json::to_string(&pk).expect("serde_json serialize public key");
+        let serde_deser_pk: PublicKey = serde_json::from_str(&serde_ser_pk).expect("serde_json deserialized public key");
+        assert_eq!(serde_ser_pk.chars().count(), PK_SIZE * 2 + 2); // accounts for that each hex byte has 2 chars, and theres leading and trailing '"'
         assert_eq!(pk, deser_pk);
+        assert_eq!(pk, serde_deser_pk);
         let ser_sig = bincode::serialize(&sig).expect("serialize signature");
         let deser_sig = bincode::deserialize(&ser_sig).expect("deserialize signature");
         assert_eq!(ser_sig.len(), SIG_SIZE);

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -428,7 +428,7 @@ impl Poly {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Commitment {
     /// The coefficients of the polynomial.
-    #[serde(with = "super::serde_impl::projective_vec")]
+    #[serde(with = "super::serde_impl::projective_publickeyset")]
     pub(super) coeff: Vec<G1>,
 }
 

--- a/src/serde_impl.rs
+++ b/src/serde_impl.rs
@@ -475,19 +475,4 @@ mod tests {
             assert_eq!(ser_val.len(), 32);
         }
     }
-
-    #[test]
-    fn serde_public_key() {
-        use crate::{PublicKey, SecretKey};
-        use serde_json;
-
-        let sk = SecretKey::random();
-        let pk0 = sk.public_key();
-
-        let ser_pk = serde_json::to_string(&pk0).unwrap();
-        let pk: PublicKey = serde_json::from_str(&ser_pk).expect("From slide went bad");
-        let pk1 = PublicKey(pk.0);
-
-        assert_eq!(pk0, pk1);
-    }
 }


### PR DESCRIPTION
These changes change how `PublicKey`, `PublicKeySet`, and `PublicKeyShare` are serialized (and deserialized) so that, when serialized with `serde_json::to_string`, they're represented as hex Strings or an object containing a list of hex Strings. The de/serialization of everything else has been left unchanged. This is meant to address https://github.com/fedimint/minimint/issues/109.